### PR TITLE
Github actions, junit dependency fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,4 +28,4 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: build-jdk-${{ matrix.java }}
-        path: target/commons-network-*.jar
+        path: target/ph-javacc-maven-plugin-*.jar

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,17 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 9, 11, 12, 13, 14, 15 ]
+        java: [ 8, 11, 17, 21 ]
     steps:
-    - uses: actions/checkout@v2
+
+    - uses: actions/checkout@v3
+
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v3
       with:
         distribution: 'adopt'
         java-version: ${{ matrix.java }}
+
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-    - uses: actions/upload-artifact@v2
+
+    - uses: actions/upload-artifact@v3
       with:
         name: build-jdk-${{ matrix.java }}
         path: target/commons-network-*.jar

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,27 @@
+name: Java CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 9, 11, 12, 13, 14, 15 ]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: ${{ matrix.java }}
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+    - uses: actions/upload-artifact@v2
+      with:
+        name: build-jdk-${{ matrix.java }}
+        path: target/commons-network-*.jar

--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,12 @@
       <artifactId>parser-generator-cc</artifactId>
       <version>1.1.4</version>
     </dependency>
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>3.8.2</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>


### PR DESCRIPTION
This fixes a missing junit 3.8 (!) dependency.
Besides that, it's adding a Github actions workflow that simply does the Maven build with all LTS JDKs.
And it's adding dependabot for updating the plugins / dependencies.
