### PR TITLE
Add scope=provided for Maven plugin dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,11 +97,13 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-api</artifactId>
       <version>${maven.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- 
     <dependency>
@@ -120,6 +122,7 @@
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>
       <version>3.1.0</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>edu.ucla.cs.compilers</groupId>


### PR DESCRIPTION
It resolves the following failure:

```
Some dependencies of Maven Plugins are expected to be in provided scope. Please make sure that dependencies listed below declared in POM have set '<scope>provided</scope>' as well.

The following dependencies are in wrong scope:
 * org.apache.maven:maven-core:jar:3.1.0:compile
 * org.apache.maven:maven-model:jar:3.1.0:compile
 * org.apache.maven:maven-settings:jar:3.1.0:compile
 * org.apache.maven:maven-settings-builder:jar:3.1.0:compile
 * org.apache.maven:maven-repository-metadata:jar:3.1.0:compile
 * org.apache.maven:maven-artifact:jar:3.1.0:compile
 * org.apache.maven:maven-model-builder:jar:3.1.0:compile
 * org.apache.maven:maven-aether-provider:jar:3.1.0:compile
```